### PR TITLE
Bump go + use upstream tracking fork

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ make intel-gpu-plugin
 export GOPATH=~/go/
 mkdir -p $GOPATH/src/github.com/kubernetes
 cd $GOPATH/src/github.com/kubernetes/
-git clone --single-branch --branch 1.16.2-plus-kubeadm-addon-installer https://github.com/dholbach/kubernetes.git --depth 2
+git clone --single-branch --branch kubeadm-addon-installer https://github.com/stealthybox/kubernetes.git --depth 2
 GO111MODULE=on bazel build //cmd/kubeadm
 ```
 

--- a/README.md
+++ b/README.md
@@ -2,12 +2,12 @@
 
 ## Prep
 
-First make sure you have go 1.12, git and bazel installed. We'll assume
+First make sure you have go 1.13, git and bazel installed. We'll assume
 you run Ubuntu or Debian here for simplicity:
 
 ```sh
 sudo apt install -y apt-transport-https git snapd curl make docker.io
-snap install go --channel 1.12/stable --classic
+snap install go --channel 1.13/stable --classic
 
 echo "deb [arch=amd64] https://storage.googleapis.com/bazel-apt stable jdk1.8" | sudo tee /etc/apt/sources.list.d/bazel.list
 curl https://bazel.build/bazel-release.pub.gpg | sudo apt-key add -

--- a/hetzner/README.md
+++ b/hetzner/README.md
@@ -15,7 +15,7 @@ hcloud server create --image=ubuntu-18.04 --name=worker-1 --type=cx11
 
 ```sh
 apt install make docker.io linux-image-generic
-snap install go --channel 1.12/stable --classic
+snap install go --channel 1.13/stable --classic
 reboot
 git clone https://github.com/intel/intel-device-plugins-for-kubernetes
 cd intel-device-plugins-for-kubernetes


### PR DESCRIPTION
Not required to merge this immediately.
We can get this in when we feel it's ready.

Changes:
  - Use stealthybox k8s fork rebased on upstream master
  - Bump go to 1.13 for k8s 1.17 alpha